### PR TITLE
networkx 2 compatibility

### DIFF
--- a/netcomp/distance/exact.py
+++ b/netcomp/distance/exact.py
@@ -11,10 +11,10 @@ import numpy as np
 from numpy import linalg as la
 import networkx as nx
 
-from netcomp.linalg import (renormalized_res_mat,resistance_matrix,
-                            fast_bp,laplacian_matrix,normalized_laplacian_eig,
-                            _flat,_pad,_eigs)
-from netcomp.distance import get_features,aggregate_features
+from netcomp.linalg import (renormalized_res_mat, resistance_matrix,
+                            fast_bp, laplacian_matrix, normalized_laplacian_eig,
+                            _flat, _pad, _eigs)
+from netcomp.distance import get_features, aggregate_features
 from netcomp.exception import InputError
 
 
@@ -23,17 +23,17 @@ from netcomp.exception import InputError
 ######################
 
 
-def _canberra_dist(v1,v2):
+def _canberra_dist(v1, v2):
     """The canberra distance between two vectors. We need to carefully handle
     the case in which both v1 and v2 are zero in a certain dimension."""
-    eps = 10**(-15)
-    v1,v2 = [_flat(v) for v in [v1,v2]]
+    eps = 10 ** (-15)
+    v1, v2 = [_flat(v) for v in [v1, v2]]
     d_can = 0
-    for u,w in zip(v1,v2):
-        if np.abs(u)<eps and np.abs(w)<eps:
+    for u, w in zip(v1, v2):
+        if np.abs(u) < eps and np.abs(w) < eps:
             d_update = 1
         else:
-            d_update = np.abs(u-w) / (np.abs(u)+np.abs(w))
+            d_update = np.abs(u - w) / (np.abs(u) + np.abs(w))
         d_can += d_update
     return d_can
 
@@ -43,7 +43,7 @@ def _canberra_dist(v1,v2):
 #############################
 
 
-def edit_distance(A1,A2):
+def edit_distance(A1, A2):
     """The edit distance between graphs, defined as the number of changes one
     needs to make to put the edge lists in correspondence.
 
@@ -57,11 +57,11 @@ def edit_distance(A1,A2):
     dist : float
         The edit distance between the two graphs
     """
-    dist = np.abs((A1-A2)).sum() / 2
+    dist = np.abs((A1 - A2)).sum() / 2
     return dist
 
 
-def vertex_edge_overlap(A1,A2):
+def vertex_edge_overlap(A1, A2):
     """Vertex-edge overlap. Basically a souped-up edit distance, but in similarity
     form. The VEO similarity is defined as
 
@@ -85,18 +85,18 @@ def vertex_edge_overlap(A1,A2):
 
     """
     try:
-        [G1,G2] = [nx.from_scipy_sparse_matrix(A) for A in [A1,A2]]
+        [G1, G2] = [nx.from_scipy_sparse_matrix(A) for A in [A1, A2]]
     except AttributeError:
-        [G1,G2] = [nx.from_numpy_matrix(A) for A in [A1,A2]]
-    V1,V2 = [set(G.nodes()) for G in [G1,G2]]
-    E1,E2 = [set(G.edges()) for G in [G1,G2]]
-    V_overlap = len(V1|V2) # set union
-    E_overlap = len(E1|E2)
-    sim = (V_overlap + E_overlap) / (len(V1)+len(V2)+len(E1)+len(E2))
+        [G1, G2] = [nx.from_numpy_matrix(A) for A in [A1, A2]]
+    V1, V2 = [set(G.nodes()) for G in [G1, G2]]
+    E1, E2 = [set(G.edges()) for G in [G1, G2]]
+    V_overlap = len(V1 | V2)  # set union
+    E_overlap = len(E1 | E2)
+    sim = (V_overlap + E_overlap) / (len(V1) + len(V2) + len(E1) + len(E2))
     return sim
 
 
-def vertex_edge_distance(A1,A2):
+def vertex_edge_distance(A1, A2):
     """Vertex-edge overlap transformed into a distance via
 
         D = (1-VEO)/VEO
@@ -115,12 +115,12 @@ def vertex_edge_distance(A1,A2):
     dist : float
         The distance between the two graphs
     """
-    sim = vertex_edge_overlap(A1,A2)
-    dist = (1-sim)/sim
+    sim = vertex_edge_overlap(A1, A2)
+    dist = (1 - sim) / sim
     return dist
 
-    
-def lambda_dist(A1,A2,k=None,p=2,kind='laplacian'):
+
+def lambda_dist(A1, A2, k=None, p=2, kind='laplacian'):
     """The lambda distance between graphs, which is defined as
 
         d(G1,G2) = norm(L_1 - L_2)
@@ -167,31 +167,31 @@ def lambda_dist(A1,A2,k=None,p=2,kind='laplacian'):
 
     """
     # ensure valid k
-    n1,n2 = [A.shape[0] for A in [A1,A2]]
-    N = min(n1,n2) # minimum size between the two graphs
+    n1, n2 = [A.shape[0] for A in [A1, A2]]
+    N = min(n1, n2)  # minimum size between the two graphs
     if k is None or k > N:
         k = N
     if kind is 'laplacian':
         # form matrices
-        L1,L2 = [laplacian_matrix(A) for A in [A1,A2]]
+        L1, L2 = [laplacian_matrix(A) for A in [A1, A2]]
         # get eigenvalues, ignore eigenvectors
-        evals1,evals2 = [_eigs(L)[0] for L in [L1,L2]]
+        evals1, evals2 = [_eigs(L)[0] for L in [L1, L2]]
     elif kind is 'laplacian_norm':
         # use our function to graph evals of normalized laplacian
-        evals1,evals2 = [normalized_laplacian_eig(A)[0] for A in [A1,A2]]
+        evals1, evals2 = [normalized_laplacian_eig(A)[0] for A in [A1, A2]]
     elif kind is 'adjacency':
-        evals1,evals2 = [_eigs(A)[0] for A in [A1,A2]]
+        evals1, evals2 = [_eigs(A)[0] for A in [A1, A2]]
         # reverse, so that we are sorted from large to small, since we care
         # about the k LARGEST eigenvalues for the adjacency distance
-        evals1,evals2 = [evals[::-1] for evals in [evals1,evals2]]
+        evals1, evals2 = [evals[::-1] for evals in [evals1, evals2]]
     else:
         raise InputError("Invalid type, choose from 'laplacian', "
                          "'laplacian_norm', and 'adjacency'.")
-    dist = la.norm(evals1[:k]-evals2[:k],ord=p)
+    dist = la.norm(evals1[:k] - evals2[:k], ord=p)
     return dist
 
 
-def netsimile(A1,A2):
+def netsimile(A1, A2):
     """NetSimile distance between two graphs.
 
     Parameters
@@ -214,16 +214,16 @@ def netsimile(A1,A2):
 
     References
     ----------
-    """ 
-    feat_A1,feat_A2 = [get_features(A) for A in [A1,A2]]
-    agg_A1,agg_A2 = [aggregate_features(feat) for feat in [feat_A1,feat_A2]]
+    """
+    feat_A1, feat_A2 = [get_features(A) for A in [A1, A2]]
+    agg_A1, agg_A2 = [aggregate_features(feat) for feat in [feat_A1, feat_A2]]
     # calculate Canberra distance between two aggregate vectors
-    d_can = _canberra_dist(agg_A1,agg_A2)
+    d_can = _canberra_dist(agg_A1, agg_A2)
     return d_can
-    
-    
-def resistance_distance(A1,A2,p=2,renormalized=False,attributed=False,
-                        check_connected=True,beta=1):
+
+
+def resistance_distance(A1, A2, p=2, renormalized=False, attributed=False,
+                        check_connected=True, beta=1):
     """Compare two graphs using resistance distance (possibly renormalized).
 
     Parameters
@@ -269,24 +269,25 @@ def resistance_distance(A1,A2,p=2,renormalized=False,attributed=False,
     # Calculate resistance matricies and compare
     if renormalized:
         # pad smaller adj. mat. so they're the same size
-        n1,n2 = [A.shape[0] for A in [A1,A2]]
-        N = max(n1,n2)
-        A1,A2 = [_pad(A,N) for A in [A1,A2]]
-        R1,R2 = [renormalized_res_mat(A,beta=beta) for A in [A1,A2]]
+        n1, n2 = [A.shape[0] for A in [A1, A2]]
+        N = max(n1, n2)
+        A1, A2 = [_pad(A, N) for A in [A1, A2]]
+        R1, R2 = [renormalized_res_mat(A, beta=beta) for A in [A1, A2]]
     else:
-        R1,R2 = [resistance_matrix(A,check_connected=check_connected)
-                 for A in [A1,A2]]
+        R1, R2 = [resistance_matrix(A, check_connected=check_connected)
+                  for A in [A1, A2]]
     try:
-        distance_vector = np.sum((R1-R2)**p,axis=1)
+        distance_vector = np.sum((R1 - R2) ** p, axis=1)
     except ValueError:
         raise InputError('Input matrices are different sizes. Please use '
                          'renormalized resistance distance.')
     if attributed:
-        return distance_vector**(1/p)
+        return distance_vector ** (1 / p)
     else:
-        return np.sum(distance_vector)**(1/p)
+        return np.sum(distance_vector) ** (1 / p)
 
-def deltacon0(A1,A2,eps=None):
+
+def deltacon0(A1, A2, eps=None):
     """DeltaCon0 distance between two graphs. The distance is the Frobenius norm
     of the element-wise square root of the fast belief propogation matrix.
 
@@ -308,9 +309,9 @@ def deltacon0(A1,A2,eps=None):
     fast_bp
     """
     # pad smaller adj. mat. so they're the same size
-    n1,n2 = [A.shape[0] for A in [A1,A2]]
-    N = max(n1,n2)
-    A1,A2 = [_pad(A,N) for A in [A1,A2]]
-    S1,S2 = [fast_bp(A,eps=eps) for A in [A1,A2]]
-    dist = np.abs(np.sqrt(S1)-np.sqrt(S2)).sum()
+    n1, n2 = [A.shape[0] for A in [A1, A2]]
+    N = max(n1, n2)
+    A1, A2 = [_pad(A, N) for A in [A1, A2]]
+    S1, S2 = [fast_bp(A, eps=eps) for A in [A1, A2]]
+    dist = np.abs(np.sqrt(S1) - np.sqrt(S2)).sum()
     return dist

--- a/netcomp/distance/features.py
+++ b/netcomp/distance/features.py
@@ -11,6 +11,7 @@ from scipy import stats
 
 from netcomp.linalg import _eps
 
+
 def get_features(A):
     """Feature grabber for NetSimile algorithm. Features used are
 
@@ -44,17 +45,17 @@ def get_features(A):
         G = nx.from_numpy_matrix(A)
     n = len(G)
     # degrees, array so we can slice nice
-    d_vec = np.array(list(G.degree().values()))
+    d_vec = np.array(list(dict(G.degree()).values()))
     # list of clustering coefficient
     clust_vec = np.array(list(nx.clustering(G).values()))
-    neighbors = [G.neighbors(i) for i in range(n)]
+    neighbors = [list(G.neighbors(i)) for i in range(n)]
     # average degree of neighbors (0 if node is isolated)
-    neighbor_deg = [d_vec[neighbors[i]].sum()/d_vec[i]
-                    if d_vec[i]>_eps else 0 for i in range(n)]
+    neighbor_deg = [d_vec[neighbors[i]].sum() / d_vec[i]
+                    if d_vec[i] > _eps else 0 for i in range(n)]
     # avg. clustering coefficient of neighbors (0 if node is isolated)
-    neighbor_clust = [clust_vec[neighbors[i]].sum()/d_vec[i] 
-                    if d_vec[i]>_eps else 0 for i in range(n)]
-    egonets = [nx.ego_graph(G,i) for i in range(n)]
+    neighbor_clust = [clust_vec[neighbors[i]].sum() / d_vec[i]
+                      if d_vec[i] > _eps else 0 for i in range(n)]
+    egonets = [nx.ego_graph(G, i) for i in range(n)]
     # number of edges in egonet
     ego_size = [G.number_of_edges() for G in egonets]
     # number of neighbors of egonet
@@ -63,18 +64,16 @@ def get_features(A):
                          set(egonets[i].nodes()))
                      for i in range(n)]
     # number of edges outgoing from egonet
-    outgoing_edges = [len([edge for edge in G.edges(egonets[i].nodes()) 
-                           if edge[1] not in egonets[i].nodes()]) 
+    outgoing_edges = [len([edge for edge in G.edges(egonets[i].nodes())
+                           if edge[1] not in egonets[i].nodes()])
                       for i in range(n)]
     # use mat.T so that each node is a row (standard format)
-    feature_mat = np.array([d_vec,clust_vec,neighbor_deg,neighbor_clust,
-                            ego_size,ego_neighbors,outgoing_edges]).T 
+    feature_mat = np.array([d_vec, clust_vec, neighbor_deg, neighbor_clust,
+                            ego_size, ego_neighbors, outgoing_edges]).T
     return feature_mat
 
 
-
-
-def aggregate_features(feature_mat,row_var=False,as_matrix=False):
+def aggregate_features(feature_mat, row_var=False, as_matrix=False):
     """Returns column-wise descriptive statistics of a feature matrix.
 
     Parameters
@@ -102,12 +101,12 @@ def aggregate_features(feature_mat,row_var=False,as_matrix=False):
     References
     ----------
     """
-    axis = int(row_var) # 0 if column-oriented, 1 if not
+    axis = int(row_var)  # 0 if column-oriented, 1 if not
     description = np.array([feature_mat.mean(axis=axis),
-                            np.median(feature_mat,axis=axis),
-                            np.std(feature_mat,axis=axis),
-                            stats.skew(feature_mat,axis=axis),
-                            stats.kurtosis(feature_mat,axis=axis)])
+                            np.median(feature_mat, axis=axis),
+                            np.std(feature_mat, axis=axis),
+                            stats.skew(feature_mat, axis=axis),
+                            stats.kurtosis(feature_mat, axis=axis)])
     if not as_matrix:
         description = description.flatten()
     return description

--- a/netcomp/linalg/eigenstuff.py
+++ b/netcomp/linalg/eigenstuff.py
@@ -12,7 +12,7 @@ from scipy.sparse import linalg as spla
 from numpy import linalg as la
 
 from scipy.sparse import issparse
-from netcomp.linalg.matrices import _flat,_eps
+from netcomp.linalg.matrices import _flat, _eps
 
 
 ######################
@@ -20,7 +20,7 @@ from netcomp.linalg.matrices import _flat,_eps
 ######################
 
 
-def _eigs(M,which='SR',k=None):
+def _eigs(M, which='SR', k=None):
     """ Helper function for getting eigenstuff.
 
     Parameters
@@ -43,34 +43,37 @@ def _eigs(M,which='SR',k=None):
     numpy.linalg.eig
     scipy.sparse.eigs        
     """
-    n,_ = M.shape
+    n, _ = M.shape
     if k is None:
         k = n
-    if which not in ['LR','SR']:
+    if which not in ['LR', 'SR']:
         raise ValueError("which must be either 'LR' or 'SR'.")
     M = M.astype(float)
-    if issparse(M) and k < n-1:
-        evals,evecs = spla.eigs(M,k=k,which=which)
+    if issparse(M) and k < n - 1:
+        evals, evecs = spla.eigs(M, k=k, which=which)
     else:
-        try: M = M.todense()
-        except: pass
-        evals,evecs = la.eig(M)
+        try:
+            M = M.todense()
+        except:
+            pass
+        evals, evecs = la.eig(M)
         # sort dem eigenvalues
         inds = np.argsort(evals)
         if which == 'LR':
             inds = inds[::-1]
-        else: pass
+        else:
+            pass
         inds = inds[:k]
         evals = evals[inds]
-        evecs = np.matrix(evecs[:,inds])
-    return np.real(evals),np.real(evecs)
+        evecs = np.matrix(evecs[:, inds])
+    return np.real(evals), np.real(evecs)
 
 
 #####################
 ##  Get Eigenstuff ##
 #####################
 
-def normalized_laplacian_eig(A,k=None):
+def normalized_laplacian_eig(A, k=None):
     """Return the eigenstuff of the normalized Laplacian matrix of graph
     associated with adjacency matrix A.
 
@@ -113,16 +116,16 @@ def normalized_laplacian_eig(A,k=None):
     nx.laplacian_matrix
     nx.normalized_laplacian_matrix
     """
-    n,m = A.shape
+    n, m = A.shape
     ##
     ## TODO: implement checks on the adjacency matrix
     ##
     degs = _flat(A.sum(axis=1))
     # the below will break if
-    inv_root_degs = [d**(-1/2) if d>_eps else 0 for d in degs]
+    inv_root_degs = [d ** (-1 / 2) if d > _eps else 0 for d in degs]
     inv_rootD = sps.spdiags(inv_root_degs, [0], n, n, format='csr')
     # build normalized diffusion matrix
-    K = inv_rootD*A*inv_rootD
-    evals,evecs = _eigs(K,k=k,which='LR')
-    lap_evals = 1-evals
-    return np.real(lap_evals),np.real(evecs)
+    K = inv_rootD * A * inv_rootD
+    evals, evecs = _eigs(K, k=k, which='LR')
+    lap_evals = 1 - evals
+    return np.real(lap_evals), np.real(evecs)

--- a/netcomp/linalg/fast_bp.py
+++ b/netcomp/linalg/fast_bp.py
@@ -10,6 +10,7 @@ from scipy import sparse as sps
 import numpy as np
 from numpy import linalg as la
 
+
 def fast_bp(A,eps=None):
     """Return the fast belief propogation matrix of graph associated with A.
 

--- a/netcomp/linalg/matrices.py
+++ b/netcomp/linalg/matrices.py
@@ -10,7 +10,8 @@ from scipy import sparse as sps
 from scipy.sparse import issparse
 import numpy as np
 
-_eps = 10**(-10) # a small parameter
+_eps = 10 ** (-10)  # a small parameter
+
 
 ######################
 ## Helper Functions ##
@@ -25,23 +26,23 @@ def _flat(D):
     return d_flat
 
 
-def _pad(A,N):
+def _pad(A, N):
     """Pad A so A.shape is (N,N)"""
-    n,_ = A.shape
-    if n>=N:
+    n, _ = A.shape
+    if n >= N:
         return A
     else:
         if issparse(A):
             # thrown if we try to np.concatenate sparse matrices
-            side = sps.csr_matrix((n,N-n))
-            bottom = sps.csr_matrix((N-n,N))
-            A_pad = sps.hstack([A,side])
-            A_pad = sps.vstack([A_pad,bottom])
+            side = sps.csr_matrix((n, N - n))
+            bottom = sps.csr_matrix((N - n, N))
+            A_pad = sps.hstack([A, side])
+            A_pad = sps.vstack([A_pad, bottom])
         else:
-            side = np.zeros((n,N-n))
-            bottom = np.zeros((N-n,N))
-            A_pad = np.concatenate([A,side],axis=1)
-            A_pad = np.concatenate([A_pad,bottom])
+            side = np.zeros((n, N - n))
+            bottom = np.zeros((N - n, N))
+            A_pad = np.concatenate([A, side], axis=1)
+            A_pad = np.concatenate([A_pad, bottom])
         return A_pad
 
 
@@ -63,13 +64,13 @@ def degree_matrix(A):
     D : SciPy sparse matrix
         Diagonal matrix of degrees.
     """
-    n,m = A.shape
+    n, m = A.shape
     degs = _flat(A.sum(axis=1))
-    D = sps.spdiags(degs,[0],n,n,format='csr')
+    D = sps.spdiags(degs, [0], n, n, format='csr')
     return D
 
 
-def laplacian_matrix(A,normalized=False):
+def laplacian_matrix(A, normalized=False):
     """Diagonal degree matrix of graph with adjacency matrix A
 
     Parameters
@@ -84,11 +85,11 @@ def laplacian_matrix(A,normalized=False):
     L : SciPy sparse matrix
         Combinatorial laplacian matrix.
     """
-    n,m = A.shape
+    n, m = A.shape
     D = degree_matrix(A)
     L = D - A
     if normalized:
         degs = _flat(A.sum(axis=1))
-        rootD = sps.spdiags(np.power(degs,-1/2), [0], n, n, format='csr')
-        L = rootD*L*rootD
+        rootD = sps.spdiags(np.power(degs, -1 / 2), [0], n, n, format='csr')
+        L = rootD * L * rootD
     return L

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 
 numpy>=1.11.3
 scipy>=0.18
-networkx<2 # No support for NetworkX 2, at the moment
+networkx
 

--- a/test.py
+++ b/test.py
@@ -6,23 +6,23 @@ import networkx as nx
 # use networkx to build a sample graph
 G0 = nx.complete_graph(10)
 G1 = G0.copy()
-G1.remove_edge(1,0)
+G1.remove_edge(1, 0)
 G2 = G0.copy()
 G2.remove_node(0)
-A,B,C = [nx.adjacency_matrix(G) for G in [G0,G1,G2]]
+A, B, C = [nx.adjacency_matrix(G) for G in [G0, G1, G2]]
 
 # matrix distances
-nc.resistance_distance(A,B);
-nc.edit_distance(A,B);
-nc.deltacon0(A,B);
-nc.vertex_edge_distance(A,B);
+nc.resistance_distance(A, B);
+nc.edit_distance(A, B);
+nc.deltacon0(A, B);
+nc.vertex_edge_distance(A, B);
 # spectral distances
-nc.lambda_dist(A,C);
-nc.lambda_dist(A,C,kind='adjacency',k=2);
-nc.lambda_dist(A,C,kind='laplacian_norm');
+nc.lambda_dist(A, C);
+nc.lambda_dist(A, C, kind='adjacency', k=2);
+nc.lambda_dist(A, C, kind='laplacian_norm');
 # other distances
-nc.resistance_distance(A,C,renormalized=True);
-nc.netsimile(A,C);
+nc.resistance_distance(A, C, renormalized=True);
+nc.netsimile(A, C);
 # matrices w/o associated distances
 nc.commute_matrix(A);
 nc.conductance_matrix(A);

--- a/test.py
+++ b/test.py
@@ -12,17 +12,17 @@ G2.remove_node(0)
 A, B, C = [nx.adjacency_matrix(G) for G in [G0, G1, G2]]
 
 # matrix distances
-nc.resistance_distance(A, B);
-nc.edit_distance(A, B);
-nc.deltacon0(A, B);
-nc.vertex_edge_distance(A, B);
+nc.resistance_distance(A, B)
+nc.edit_distance(A, B)
+nc.deltacon0(A, B)
+nc.vertex_edge_distance(A, B)
 # spectral distances
-nc.lambda_dist(A, C);
-nc.lambda_dist(A, C, kind='adjacency', k=2);
-nc.lambda_dist(A, C, kind='laplacian_norm');
+nc.lambda_dist(A, C)
+nc.lambda_dist(A, C, kind='adjacency', k=2)
+nc.lambda_dist(A, C, kind='laplacian_norm')
 # other distances
-nc.resistance_distance(A, C, renormalized=True);
-nc.netsimile(A, C);
+nc.resistance_distance(A, C, renormalized=True)
+nc.netsimile(A, C)
 # matrices w/o associated distances
-nc.commute_matrix(A);
-nc.conductance_matrix(A);
+nc.commute_matrix(A)
+nc.conductance_matrix(A)


### PR DESCRIPTION
This version allows using both networkx 1 and networkx 2.
Most changes are connected to formating.

Main changes to allow networkx 2 usage are:
- ```(G.subgraph(c).copy() for c in nx.connected_components(G))``` instead of ```nx.connected_component_subgraphs(G)``` (cause the function was deprecated) [ here](https://github.com/peterewills/NetComp/compare/master...YamLyubov:NetComp:add-networkx-2?expand=1#diff-7a1f7857f652dc385ce2da23289b3ab0b54f71cb3fb5993fb51ad32173277a5cR175) and [here](https://github.com/peterewills/NetComp/compare/master...YamLyubov:NetComp:add-networkx-2?expand=1#diff-7a1f7857f652dc385ce2da23289b3ab0b54f71cb3fb5993fb51ad32173277a5cR232) 
- converting returned object to dict ```list(dict(G.degree()).values())``` instead of ```list(G.degree().values())``` [here](https://github.com/peterewills/NetComp/pull/3/files#diff-3e387b1aba9010de95e45d6439d8181f8ca97d622a34510556c7677353b61d53R48)
- converting returned object to list ```[list(G.neighbors(i)) for i in range(n)]``` instead of ```[G.neighbors(i) for i in range(n)]``` [here](https://github.com/peterewills/NetComp/compare/master...YamLyubov:NetComp:add-networkx-2?expand=1#diff-3e387b1aba9010de95e45d6439d8181f8ca97d622a34510556c7677353b61d53R51)

#2